### PR TITLE
basic teamcity reporter from mocha

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -1,0 +1,1 @@
+exports = module.exports = require('mocha-teamcity-reporter');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "3.10.1",
     "minimatch": "2.0.10",
     "mocha": "2.4.5",
+    "mocha-teamcity-reporter": "1.0.0",
     "vow": "0.4.12",
     "vow-fs": "0.3.4"
   },


### PR DESCRIPTION
Just pass mocha-teamcity-reporter to enb-bem-tmpl-specs as is. Use case — run in teamcity with both teamcith,html reporters.

Teamcity reporter will be used to gather tests stats (total count, failed, passed), html — to deep into errors.