### PR TITLE
Save html reference near bemjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,15 @@ BEM_TMPL_SPECS_REPORTERS=html,summary,spec
 Сохранение результатов
 ----------------------
 
-Для сохранения результатов отрисовки HTML вы можете либо выставить явно флаг `saveHtml` при конфигурации технологии, либо через переменную окружения:
-```sh
-BEM_TMPL_SPECS_SAVE_HTML=1
-```
+Для сохранения результатов отрисовки HTML вы можете либо выставить явно флаг `saveHtml` при конфигурации технологии, либо через переменную окружения — `BEM_TMPL_SPECS_SAVE_HTML=1`.
+
+Файл будет сохранён в `<set-name>.tmpl-specs/<block-name>/*.html`, рядом со сгенерированными файлами тестов.
+
+Создание эталонов
+----------------------
+Для создания/обновления HTML эталонов вы можете либо выставить явно флаг `saveReferenceHtml` при конфигурации технологии, либо через переменную окружения — `BEM_TMPL_SPECS_SAVE_REFERENCE_HTML=1`
+
+Файл будет сохранён в `<level>.blocks/<block-name>/<block-name>.tmpl-specs/*.html`, рядом с исходным кодом блока.
 
 Фильтрация тестов
 -----------------
@@ -231,7 +236,8 @@ module.exports = function (config) {
   - *Object* `options` — опции для ENB-технологии;
   - *Boolean* `async` — асинхронный шаблонизатор;
 * *String* `completeBundle` – имя бандла, в котором будут собраны все БЭМ-сущности из уровней `levels`. По умолчанию `completeBundle` не будет собран.
-* *Boolean* `saveHtml` — сохранять результат html при успешной отрисовке в файл (env: `BEM_TMPL_SPECT_SAVE_HTML`);
+* *Boolean* `saveHtml` — сохранять результат HTML при успешной отрисовке в файл (env: `BEM_TMPL_SPECS_SAVE_HTML`);
+* *Boolean* `saveReferenceHtml` — создать/обновить эталон HTML рядом с BEMJSON (env: `BEM_TMPL_SPECS_SAVE_REFERENCE_HTML`);
 * *String|Function* `depsTech` — технология для раскрытия зависимостей. По умолчанию — `deps-old`.
 * *Function* `mockI18N` — функция будет использована вместо ядра `i18n`, если указана опция `langs: true`.
 

--- a/lib/assets/it.jst
+++ b/lib/assets/it.jst
@@ -2,47 +2,48 @@
 // prepares
 var titleSuffix = lang ? ' in `' + lang + '` lang' : '';
 var subreference = lang ? '[\'' + lang + '\']' : '';
-var prettifyEngineName = function (ngn) {
-    return lang ? String(ngn).toLowerCase().replace(' ', '-') + '.' + lang : ngn;
-};
-if (saveHtml) {
-    var filename = [it, prettifyEngineName(engine.name), 'html'].join('.');
-}
 %>
-it('should be equal `${ it }` by ${ engine.name }${ titleSuffix }', function (<% if (saveHtml || engine.async) { %>done<% } %>) {
+
+it('should be equal `${ it }` by ${ engine.name }${ titleSuffix }', function () {
     ${ before }
 
-    var bemjson = references['${ it }']${ subreference }.bemjson,
-        expected = references['${ it }']${ subreference }.html;<%
+    var ref = references['${ it }']${ subreference },
+        bemjson = ref.bemjson,
+        expected = ref.html;
 
-if (!engine.async) { %>
-    // sync mode
-    var actual = engine.apply(bemjson);
+    <% if (saveHtml || saveReferenceHtml) { %>
+        var filenames = [];
+    <% } %>
 
+    <% if (saveReferenceHtml) {%>
+        filenames.push(path.join(ref.dir, '${ referenceHtmlFilename }'));
+    <% } %>
 
-<% if (saveHtml) { %>
-    assertHtml(actual, expected, done, '${ filename }');
-<% } else {%>
-    assertHtml(actual, expected);
-<% }
-} else { // engine.async %>
-    // async mode
-    engine.apply(bemjson, function(errs, actual) {
-        if (errs !== null) {
-            done(errs);
-            return;
-        }
+    <% if (saveHtml) {%>
+        filenames.push(path.join(__dirname, '${ htmlFilename }'));
+    <% } %>
 
-        assertHtml(actual, expected, function(err) {
-<% if (saveHtml) {%>
-            saveHtmlFile('${ filename }', actual, function() {
-                done(err || null);
+    return new vow.Promise(function(resolve, reject) {
+        <% if (engine.async) { %>
+            engine.apply(bemjson, function(errs, actual) {
+                if (errs !== null) {
+                    reject(errs);
+                    return;
+                }
+
+                resolve(actual);
             });
-<% } else { %>
-            done(err || null);
-<% } %>
-        });
-    });<%
-} %>
+        <% } else { %>
+            resolve(engine.apply(bemjson));
+        <% } %>
+    }).then(function(actual) {
+        <% if (saveHtml || saveReferenceHtml) { %>
+            return saveHtmlFile(filenames, actual).always(function() {
+                return assertHtml(actual, expected);
+            });
+        <% } else { %>
+            return assertHtml(actual, expected);
+        <% } %>
+    });
 
 });

--- a/lib/assets/tmpl-spec.jst
+++ b/lib/assets/tmpl-spec.jst
@@ -1,7 +1,8 @@
 var assert = require('assert'),
     path = require('path'),
-<% if (saveHtml) { %>
-    fs = require('fs'),
+    vow = require('${ paths['vow'] }'),
+<% if (saveHtml || saveReferenceHtml) { %>
+    vowFs = require('${ paths['vow-fs'] }'),
     beautifyHtml = function(html) {
         return require('${ paths['js-beautify'] }').html(html, beautifyHtmlConfig);
     },
@@ -14,8 +15,15 @@ var assert = require('assert'),
     'font', 'ins', 'del', 'pre', 'address', 'dt',
     'q', 'i', 'b', 'u', 's', 'bdo', 'em'
     ]},
-    saveHtmlFile = function(filename, actual, done) {
-        fs.writeFile(path.join(__dirname, filename), beautifyHtml(actual), done);
+    saveHtmlFile = function(filenames, actual) {
+        if (!Array.isArray(filenames)) {
+            filenames = [filenames];
+        }
+        var html = beautifyHtml(actual);
+
+        return vow.all(filenames.map(function(filename) {
+            return vowFs.write(filename, html, 'utf8');
+        }));
     },
 <% } %>
     clearRequire = require('${ paths['clear-require'] }'),
@@ -26,12 +34,30 @@ var assert = require('assert'),
         return JSON.parse(referencesJSON);
     };
 
+<%
+var prettifyEngineName = function(ngn) {
+    return String(ngn).toLowerCase().replace(' ', '-');
+}
+%>
+
 describe('${ describe }', function() {
     <% _.forEach(its, function(it) { %>
     describe('${ it }', function() {
 
         <% _.forEach(engines, function(engine) {
-            var lang = engine.lang;
+            var lang = engine.lang,
+                filename = it,
+                engineName = prettifyEngineName(engine.name);
+
+            lang = lang.isReal ? lang.name : null;
+
+            filename += '.' + engineName;
+
+            if (lang) {
+                filename += '.' + lang;
+            }
+
+            filename += '.html';
 
             print(template('it', {
                 it: it,
@@ -40,8 +66,11 @@ describe('${ describe }', function() {
                     'var engine = ' + loadTemplate(engine.target, engine.exportName) + ';',
                 ].join('\n'),
                 engine: engine,
-                lang: lang.isReal ? lang.name : null,
-                saveHtml: saveHtml
+                lang: lang,
+                saveHtml: saveHtml,
+                saveReferenceHtml: saveReferenceHtml,
+                htmlFilename: filename,
+                referenceHtmlFilename: engines.length > 1 ? filename : filename.replace('.' + engineName, '')
             }));
         }); %>
 
@@ -50,20 +79,13 @@ describe('${ describe }', function() {
 
 }); // /describe ${ describe }
 
-function assertHtml(actual, expected, done, filename) {
-<% if (saveHtml) {%>
-    saveHtmlFile(filename, actual, function() {
-<% } %>
-    if (htmlDiffer.isEqual(actual, expected)) {
+function assertHtml(actual, expected) {
+   if (htmlDiffer.isEqual(actual, expected)) {
         // Throw error if actual is empty
         assert.ok(actual);
-        done && done(null);
     } else {
         assert.fail(actual, expected, null, '\n');
     }
-<% if (saveHtml) {%>
-    });
-<% } %>
 }
 <%
 function loadTemplate(target, exportName) {

--- a/lib/node-configurator.js
+++ b/lib/node-configurator.js
@@ -144,12 +144,16 @@ exports.configure = function (config, options) {
         });
 
         nodeConfig.addTechs([
-            [references, { dirsTarget: '?.base.dirs' }],
+            [references, {
+                dirsTarget: '?.base.dirs',
+                saveReferenceHtml: options.saveReferenceHtml
+            }],
             [spec, {
                 engineTargets: engineTargets,
                 specTargets: specTargets,
                 diffOpts: options.diffOpts,
                 saveHtml: options.saveHtml,
+                saveReferenceHtml: options.saveReferenceHtml,
                 isCoverageBundle: isCoverageBundle
             }]
         ]);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -103,6 +103,9 @@ module.exports = function (helper, commonOpts) {
                 saveHtml: (typeof process.env.BEM_TMPL_SPECS_SAVE_HTML === 'undefined' ?
                     options.saveHtml :
                     process.env.BEM_TMPL_SPECS_SAVE_HTML) || false,
+                saveReferenceHtml: (typeof process.env.BEM_TMPL_SPECS_SAVE_REFERENCE_HTML === 'undefined' ?
+                    options.saveReferenceHtml :
+                    process.env.BEM_TMPL_SPECS_SAVE_REFERENCE_HTML) || false,
                 depsTech: options.depsTech
             };
         },
@@ -180,11 +183,12 @@ module.exports = function (helper, commonOpts) {
                     appendFiles: options.appendFiles,
                     engines: options.engines,
                     saveHtml: options.saveHtml,
+                    saveReferenceHtml: options.saveReferenceHtml,
                     coverage: options.coverage,
                     sublevels: options.sublevels,
                     depsTech: options.depsTech,
                     completeBundle: options.completeBundle,
-                    diffOpts: commonOpts.diffOpts,
+                    diffOpts: commonOpts.diffOpts
                 });
             });
         },

--- a/lib/techs/references.js
+++ b/lib/techs/references.js
@@ -10,12 +10,14 @@ var path = require('path'),
 module.exports = buildFlow.create()
     .name('references')
     .target('target', '?.references.js')
+    .defineOption('saveReferenceHtml', false)
     .useDirList('tmpl-specs')
     .builder(function (dirs) {
         var target = this._target,
             logger = this.node.getLogger(),
             bemjsons = [],
-            htmls = [];
+            htmls = [],
+            saveReferenceHtml = this._saveReferenceHtml;
 
         dirs.forEach(function (dir) {
             dir.files.forEach(function (file) {
@@ -50,7 +52,8 @@ module.exports = buildFlow.create()
                         return {
                             name: name,
                             lang: lang,
-                            code: code
+                            code: code,
+                            dir: path.dirname(filename)
                         };
                     });
             })),
@@ -74,14 +77,16 @@ module.exports = buildFlow.create()
                 var name = bemjson.name,
                     code = bemjson.code,
                     lang = bemjson.lang,
+                    dir = bemjson.dir,
                     reference = references[name] || (references[name] = {});
 
                 if (lang) {
-                    reference[lang] || (reference[lang] = {});
-                    reference[lang].bemjson = code;
-                } else {
-                    reference.bemjson = code;
+                    reference = reference[lang] || (reference[lang] = {});
                 }
+
+                reference.bemjson = code;
+                reference.name = name;
+                reference.dir = dir;
             });
 
             htmls.forEach(function (html) {
@@ -91,11 +96,10 @@ module.exports = buildFlow.create()
                     reference = references[name] || (references[name] = {});
 
                 if (lang) {
-                    reference[lang] || (reference[lang] = {});
-                    reference[lang].html = source;
-                } else {
-                    reference.html = source;
+                    reference = reference[lang] || (reference[lang] = {});
                 }
+
+                reference.html = source;
             });
 
             Object.keys(references).forEach(function (name) {
@@ -128,11 +132,16 @@ module.exports = buildFlow.create()
 
                     logger.logWarningAction('references', target, message);
 
+                    if (noHtml && saveReferenceHtml) {
+                        references[name].html = '';
+                        return;
+                    }
+
                     delete references[name];
                 }
             });
 
-            return 'module.exports = ' + JSON.stringify(references) + ';';
+            return 'module.exports = ' + JSON.stringify(references, null, 4) + ';';
         });
     })
     .createTech();

--- a/lib/techs/tmpl-spec.js
+++ b/lib/techs/tmpl-spec.js
@@ -13,6 +13,8 @@ var path = require('path'),
     clearRequireFilename = require.resolve('clear-require'),
     htmlDifferFilename = require.resolve('html-differ'),
     jsBeautifyFilename = require.resolve('js-beautify'),
+    vowFilename = require.resolve('vow'),
+    vowFsFilename = require.resolve('vow-fs'),
     relativePath = function (dirname, filename) {
         return './' + path.relative(dirname, filename).replace(/\\\\/g, '/');
     },
@@ -28,6 +30,7 @@ module.exports = buildFlow.create()
     .defineRequiredOption('specTargets')
     .defineOption('diffOpts')
     .defineOption('saveHtml', false)
+    .defineOption('saveReferenceHtml', false)
     .defineOption('isCoverageBundle', false)
     .useSourceFilename('references', '?.references.js')
     .useSourceListFilenames('engineTargets', [])
@@ -45,6 +48,7 @@ module.exports = buildFlow.create()
             specTargets = this._specTargets,
             diffOpts = this._diffOpts,
             saveHtml = this._saveHtml,
+            saveReferenceHtml = this._saveReferenceHtml,
 
             references = require(referencesFilename),
             its = !this._isCoverageBundle ? Object.keys(references) : [],
@@ -52,6 +56,7 @@ module.exports = buildFlow.create()
             data = {
                 describe: path.basename(nodePath) + ' (' + path.dirname(nodePath) + ')',
                 its: its,
+                references: references,
                 engines: specTargets.map(function (specTarget) {
                     var target = specTarget.target,
                         engine = specTarget.engine,
@@ -71,10 +76,13 @@ module.exports = buildFlow.create()
                     references: referencesFilename,
                     'clear-require': clearRequireFilename,
                     'html-differ': htmlDifferFilename,
-                    'js-beautify': jsBeautifyFilename
+                    'js-beautify': jsBeautifyFilename,
+                    vow: vowFilename,
+                    'vow-fs': vowFsFilename
                 }, _.partial(relativePath, nodeDirname)),
                 diffOpts: diffOpts,
-                saveHtml: saveHtml
+                saveHtml: saveHtml,
+                saveReferenceHtml: saveReferenceHtml
             };
 
         return readAssets.spread(function (asset, it) {


### PR DESCRIPTION
С опцией `saveHtml` рядом с исходным `10-suite.bemjson.js` будет появляться эталон `10-suite.html`.

Текущая реализация перезапишет эталон, если он существует.  С точки зрения git изменений не будет. Если делать только добавление эталонов (без перезаписи), то для обновления эталона, нужно будет удалять старый файл. Но можно и откатить перезапись.